### PR TITLE
Aggiunti comandi latex \glock e \dext

### DIFF
--- a/commons/config.tex
+++ b/commons/config.tex
@@ -82,3 +82,11 @@
 \newcommand{\modifiche}{\@modifiche}
 
 \makeatother 
+
+%--------------------------------------------------
+% Comandi per i documenti esterni e il glossario
+%--------------------------------------------------
+
+\newcommand{\dext}[1]{\textsc{#1\textsubscript{\textit{D}}}}
+
+\newcommand{\glock}[1]{\textsc{#1\textsubscript{\textit{G}}}}


### PR DESCRIPTION
Entrambi i comandi scrivono i termini in maiuscoletto.
\glock: marca i termini del glossario aggiungendo G a pedice.
\dext: marca i documenti esterni aggiungendo D a pedice.