### PR TITLE
Aggiornata CI - migliorato calcolo Gulpease

### DIFF
--- a/.github/files_to_compile
+++ b/.github/files_to_compile
@@ -21,5 +21,6 @@ interni/verbali/V19
 esterni/piano_progetto
 esterni/piano_di_qualifica
 esterni/analisi_dei_requisiti
+esterni/glossario
 esterni/verbali/VE01
 esterni/verbali/VE02

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout repository contents
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Latex compiler
       uses: Jatus93/Latex-multicompiler@master
@@ -26,13 +26,14 @@ jobs:
         languages: "en_GB;en_US;italiano"
 
     - name: Gulpease
-      uses: Jatus93/GulpeaseAction@master
+      uses: achimett/GulpeaseTex@master
       with:
-        directory: ./Documents
+        files-to-evaluate: .github/files_to_compile
+        directory: Documents/Gulpease
 
     - name: Upload artifact
       if: ${{ !env.ACT }}
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: Documents
         path: ./Documents


### PR DESCRIPTION
- Script python per Gulpease riscritto da zero con regexp verificate su https://regex101.com
- Gulpease non viene più calcolato sui pdf ma su txt derivati direttamente dai file tex in modo da avere una maggiore pulizia del testo valutato
- Passate actions checkout e upload-artifact da v1 a v2
- Aggiunto glossario nei file da compilare e valutare
